### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,7 +73,7 @@ release = nvector.__version__
 # The short X.Y version (including .devXXXX, rcX, b1 suffixes if present)
 version = re.sub(r'(\d+\.\d+)\.\d+(.*)', r'\1\2', release)
 version = re.sub(r'(\.dev\d+).*?$', r'\1', version)
-print("%s %s" % (version, release))
+print("{0!s} {1!s}".format(version, release))
 
 # The full version, including alpha/beta/rc tags.
 #release = '0.4.1'  # Is set by calling `setup.py docs`
@@ -182,17 +182,17 @@ def linkcode_resolve(domain, info):
         lineno = None
 
     if lineno:
-        linespec = "#L%d-L%d" % (lineno, lineno + len(source) - 1)
+        linespec = "#L{0:d}-L{1:d}".format(lineno, lineno + len(source) - 1)
     else:
         linespec = ""
 
     fn = relpath(fn, start=dirname(nvector.__file__))
 
     if 'dev' in nvector.__version__:
-        return "http://github.com/pbrod/nvector/blob/master/nvector/%s%s" % (
+        return "http://github.com/pbrod/nvector/blob/master/nvector/{0!s}{1!s}".format(
            fn, linespec)
     else:
-        return "http://github.com/pbrod/nvector/blob/v%s/nvector/%s%s" % (
+        return "http://github.com/pbrod/nvector/blob/v{0!s}/nvector/{1!s}{2!s}".format(
            nvector.__version__, fn, linespec)
 
 

--- a/nvector/_core.py
+++ b/nvector/_core.py
@@ -1178,7 +1178,7 @@ def mean_horizontal_position(n_EB_E):
 
 def test_docstrings():
     import doctest
-    print('Testing docstrings in %s' % __file__)
+    print('Testing docstrings in {0!s}'.format(__file__))
     doctest.testmod(optionflags=doctest.NORMALIZE_WHITESPACE)
     print('Docstrings tested')
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:pbrod:Nvector?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:pbrod:Nvector?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)